### PR TITLE
change respond form to set the current request to the same request af…

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -77,11 +77,11 @@ const getContexts = dispatchFunc => {
     });
 };
 
-const createAnswer = (newAnswer, fn, topicid) => {
+const createAnswer = (newAnswer, id, dispatchFunc) => {
   return axiosWithAuth()
     .post(`/surveys/response`, newAnswer)
     .then(response => {
-      getTopicById(fn, topicid);
+      getRequestById(id, dispatchFunc);
     })
     .catch(err => {
       console.log(err);

--- a/src/components/pages/Surveys/RespondForm.js
+++ b/src/components/pages/Surveys/RespondForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Form, Input, Button } from 'antd';
 import { createAnswer } from '../../../api/index';
-import { getCurrentTopic } from '../../../state/actions/apolloActions';
+import { getCurrentRequest } from '../../../state/actions/apolloActions';
 
 const RespondForm = props => {
   const { TextArea } = Input;
@@ -50,12 +50,8 @@ const RespondForm = props => {
     return false;
   };
 
-  const responseSubmit = e => {
-    createAnswer(responses, props.getCurrentTopic, props.currentTopic.topicId)
-      .then(result => {})
-      .catch(err => {
-        console.log(err);
-      });
+  const responseSubmit = (id, func) => {
+    createAnswer(responses, id, func);
   };
 
   return (
@@ -107,7 +103,12 @@ const RespondForm = props => {
                 color: 'white',
                 fontWeight: 'bold',
               }}
-              onClick={responseSubmit}
+              onClick={() =>
+                responseSubmit(
+                  props.currentRequest.surveyid,
+                  props.getCurrentRequest
+                )
+              }
             >
               Submit
             </Button>
@@ -125,4 +126,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, { getCurrentTopic })(RespondForm);
+export default connect(mapStateToProps, { getCurrentRequest })(RespondForm);


### PR DESCRIPTION
- fixed issue when responding to a request it would change to most recent if you were on an older request and responding,
- respond now uses setcurrentRequest action and api call after respond is sent.


- [x] Is there a description to this pull request that points to a specific user story, feature, or bugfix?
- [x] Are there comments where the code may be unclear?
- [x] Is all dead code, commented out code, etc. removed?
- [ ] Are there tests written for these changes?
- [ ] Does the ReadMe need to be updated?


## Before being merged by the TPL:

- [x] Has the pull request been reviewed by at least two team members? 
- [x] Did they leave any comments or suggestions? 
- [ ] Were those suggestions acted on?
- [ ] Are all tests passing?
- [ ] Has the documentation been updated?
